### PR TITLE
Add log to file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,18 @@ dependencies {
 ```
 
 # Task Configuration
-The plugin is not especially configurable, but each task can be configured to log a warning about dependency issues rather than breaking the build like so:
+The plugin is not especially configurable, but each task can be configured to log a warning about dependency issues rather than breaking the build.
+Each task can also be configured to log informational output into a file instead of the Gradle console, this can be helpful for large projects where printing all the dependencies can cause high memory usage.
+Informational messages are logged to $builddir/dependency-analyze/.
 ```gradle
 analyzeClassesDependencies {
   justWarn = true
+  logDependencyInformationToFiles = true
 }
 
 analyzeTestClassesDependencies {
   justWarn = true
+  logDependencyInformationToFiles = true
 }
 ```
 

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
@@ -82,11 +82,9 @@ class AnalyzeDependenciesTask extends DefaultTask {
       )
       if (logDependencyInformationToFiles) {
         Files.createDirectories(outputDirectory.toPath())
-        Files.newOutputStream(outputDirectory.toPath().resolve("allArtifactFiles.log")).withCloseable { final outputStream ->
-          new PrintWriter(new BufferedOutputStream(outputStream)).withCloseable { final allFilesWriter ->
-            allFilesWriter.println("All artifact files:")
-            files.forEach { final file -> allFilesWriter.println(file) }
-          }
+        new PrintWriter(Files.newOutputStream(outputDirectory.toPath().resolve("allArtifactFiles.log"))).withCloseable { final printWriter ->
+            printWriter.println("All artifact files:")
+            files.forEach { final file -> printWriter.println(file) }
         }
       } else {
         logger.info "All Artifact Files: $files"
@@ -102,12 +100,10 @@ class AnalyzeDependenciesTask extends DefaultTask {
           getFirstLevelFiles(allowedToUse, 'allowed to use')
       if (logDependencyInformationToFiles) {
         Files.createDirectories(outputDirectory.toPath())
-        Files.newOutputStream(outputDirectory.toPath().resolve("allRequiredFiles.log")).withCloseable { final outputStream ->
-          new PrintWriter(new BufferedOutputStream(outputStream)).withCloseable { final allFilesWriter ->
-            allFilesWriter.println("Actual required files:")
-            files.forEach { final file -> allFilesWriter.println(file) }
+        new PrintWriter(Files.newOutputStream(outputDirectory.toPath().resolve("allRequiredFiles.log"))).withCloseable { final printWriter ->
+            printWriter.println("Actual required files:")
+            files.forEach { final file -> printWriter.println(file) }
           }
-        }
       } else {
         logger.info "Actual required files: $files"
       }
@@ -137,11 +133,9 @@ class AnalyzeDependenciesTask extends DefaultTask {
     )
     if (logDependencyInformationToFiles) {
       Files.createDirectories(outputDirectory.toPath())
-      Files.newOutputStream(outputDirectory.toPath().resolve("firstLevel${name.capitalize()}.log")).withCloseable { final outputStream ->
-        new PrintWriter(new BufferedOutputStream(outputStream)).withCloseable { final allFilesWriter ->
-          allFilesWriter.println("First level $name files:")
-          files.forEach { final file -> allFilesWriter.println(file) }
-        }
+      new PrintWriter(Files.newOutputStream(outputDirectory.toPath().resolve("first level ${name}.log"))).withCloseable { final printWriter ->
+          printWriter.println("First level $name files:")
+          files.forEach { final file -> printWriter.println(file) }
       }
     } else {
       logger.info "First level $name files: $files"

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
@@ -7,21 +7,25 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.artifacts.DefaultResolvedArtifact
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
 import java.lang.reflect.Method
+import java.nio.file.Files
 
 class AnalyzeDependenciesTask extends DefaultTask {
+  public static final String DEPENDENCY_ANALYZE_DEPENDENCY_DIRECTORY_NAME = "dependency-analyze"
   @Input
   boolean justWarn = false
+  @Input
+  boolean logDependencyInformationToFiles = false
   List<Configuration> require = []
   List<Configuration> allowedToUse = []
   List<Configuration> allowedToDeclare = []
   @InputFiles
   FileCollection classesDirs = project.files()
-  @OutputFile
-  File outputFile = project.file("$project.buildDir/dependency-analyze/$name")
+  @OutputDirectory
+  File outputDirectory = project.file("$project.buildDir/$DEPENDENCY_ANALYZE_DEPENDENCY_DIRECTORY_NAME/")
 
   AnalyzeDependenciesTask() {
     def methods = outputs.class.getMethods().grep {Method m -> m.name == 'cacheIf'}
@@ -39,7 +43,7 @@ class AnalyzeDependenciesTask extends DefaultTask {
     logger.info "Analyzing dependencies of $classesDirs for [require: $require, allowedToUse: $allowedToUse, " +
         "allowedToDeclare: $allowedToDeclare]"
     ProjectDependencyAnalysis analysis =
-        new ProjectDependencyResolver(project, require, allowedToUse, allowedToDeclare, classesDirs)
+        new ProjectDependencyResolver(project, require, allowedToUse, allowedToDeclare, classesDirs, logDependencyInformationToFiles)
             .analyzeDependencies()
     StringBuffer buffer = new StringBuffer()
     ['usedUndeclaredArtifacts', 'unusedDeclaredArtifacts'].each {section ->
@@ -52,6 +56,7 @@ class AnalyzeDependenciesTask extends DefaultTask {
         }
       }
     }
+    final def outputFile = new File(outputDirectory, name)
     outputFile.parentFile.mkdirs()
     outputFile.text = buffer.toString()
     if (buffer) {
@@ -75,7 +80,17 @@ class AnalyzeDependenciesTask extends DefaultTask {
               *.allModuleArtifacts
               *.file.flatten() as Set<File>
       )
-      logger.info "All Artifact Files: $files"
+      if (logDependencyInformationToFiles) {
+        Files.createDirectories(outputDirectory.toPath())
+        Files.newOutputStream(outputDirectory.toPath().resolve("allArtifactFiles.log")).withCloseable { final outputStream ->
+          new PrintWriter(new BufferedOutputStream(outputStream)).withCloseable { final allFilesWriter ->
+            allFilesWriter.println("All artifact files:")
+            files.forEach { final file -> allFilesWriter.println(file) }
+          }
+        }
+      } else {
+        logger.info "All Artifact Files: $files"
+      }
       files
     })
   }
@@ -85,7 +100,17 @@ class AnalyzeDependenciesTask extends DefaultTask {
     project.files({
       def files = getFirstLevelFiles(require, 'required') -
           getFirstLevelFiles(allowedToUse, 'allowed to use')
-      logger.info  "Actual required files: $files"
+      if (logDependencyInformationToFiles) {
+        Files.createDirectories(outputDirectory.toPath())
+        Files.newOutputStream(outputDirectory.toPath().resolve("allRequiredFiles.log")).withCloseable { final outputStream ->
+          new PrintWriter(new BufferedOutputStream(outputStream)).withCloseable { final allFilesWriter ->
+            allFilesWriter.println("Actual required files:")
+            files.forEach { final file -> allFilesWriter.println(file) }
+          }
+        }
+      } else {
+        logger.info "Actual required files: $files"
+      }
       files
     })
   }
@@ -110,7 +135,17 @@ class AnalyzeDependenciesTask extends DefaultTask {
             ProjectDependencyResolver.removeNulls(configurations)
         )*.moduleArtifacts*.file.flatten()
     )
-    logger.info "First level $name files: $files"
+    if (logDependencyInformationToFiles) {
+      Files.createDirectories(outputDirectory.toPath())
+      Files.newOutputStream(outputDirectory.toPath().resolve("firstLevel${name.capitalize()}.log")).withCloseable { final outputStream ->
+        new PrintWriter(new BufferedOutputStream(outputStream)).withCloseable { final allFilesWriter ->
+          allFilesWriter.println("First level $name files:")
+          files.forEach { final file -> allFilesWriter.println(file) }
+        }
+      }
+    } else {
+      logger.info "First level $name files: $files"
+    }
     files
   }
 }

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/ProjectDependencyResolver.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/ProjectDependencyResolver.groovy
@@ -95,19 +95,14 @@ class ProjectDependencyResolver {
     if (logDependencyInformationToFile) {
       final def outputDirectoryPath = buildDirPath.resolve(AnalyzeDependenciesTask.DEPENDENCY_ANALYZE_DEPENDENCY_DIRECTORY_NAME)
       Files.createDirectories(outputDirectoryPath)
-      final Path analyzeOutputPath = outputDirectoryPath.resolve("analyzeDependencies.txt")
-      Files.newOutputStream(analyzeOutputPath).withCloseable { final analyzeOutputStream ->
-        new PrintWriter(new BufferedOutputStream(analyzeOutputStream)).withCloseable { final analyzeWriter ->
+      final Path analyzeOutputPath = outputDirectoryPath.resolve("analyzeDependencies.log")
+        new PrintWriter(Files.newOutputStream(analyzeOutputPath)).withCloseable { final analyzeWriter ->
           analyzeWriter.println('dependencyArtifacts:')
-          for (final def artifact : dependencyArtifacts) {
-            analyzeWriter.println(artifact)
-          }
+          dependencyArtifacts.forEach({ final artifact -> analyzeWriter.println(artifact) })
           analyzeWriter.println()
 
           analyzeWriter.println("allDependencyArtifacts:")
-          for (final def artifact : allDependencyArtifacts) {
-            analyzeWriter.println(artifact)
-          }
+          allDependencyArtifacts.forEach({ final artifact -> analyzeWriter.println(artifact) })
           analyzeWriter.println()
 
           analyzeWriter.println("fileClassMap:")
@@ -117,61 +112,42 @@ class ProjectDependencyResolver {
               analyzeWriter.print(theClass)
               analyzeWriter.print(', ')
             }
+              analyzeWriter.println()
           }
           analyzeWriter.println()
 
           analyzeWriter.println("dependencyClasses:")
-          for (final depClass : dependencyClasses) {
-            analyzeWriter.println(depClass)
-          }
+          dependencyClasses.forEach({ final dependencyClass -> analyzeWriter.println(dependencyClass) })
           analyzeWriter.println()
 
           analyzeWriter.println("usedArtifacts:")
-          for (final usedArtifact : usedArtifacts) {
-            analyzeWriter.println(usedArtifact)
-          }
+          usedArtifacts.forEach({ final usedArtifact -> analyzeWriter.println(usedArtifact) })
           analyzeWriter.println()
 
-          usedDeclaredArtifacts.retainAll(usedArtifacts)
           analyzeWriter.println("usedDeclaredArtifacts:")
-          for (final usedDeclaredArtifact : usedDeclaredArtifacts) {
-            analyzeWriter.println(usedDeclaredArtifact)
-          }
+          usedDeclaredArtifacts.forEach({ final usedDeclaredArtifact -> analyzeWriter.println(usedDeclaredArtifact) })
           analyzeWriter.println()
 
-          usedUndeclaredArtifacts.removeAll(dependencyArtifacts)
           analyzeWriter.println("usedUndeclaredArtifacts:")
-          for (final usedUndeclared : usedUndeclaredArtifacts) {
-            analyzeWriter.println(usedUndeclared)
-          }
+          usedUndeclaredArtifacts.forEach({ final usedUndeclared -> analyzeWriter.println(usedUndeclared) })
           analyzeWriter.println()
 
-          unusedDeclaredArtifacts.removeAll(usedArtifacts)
           analyzeWriter.println("unusedDeclaredArtifacts:")
-          for (final unusedDelcared : unusedDeclaredArtifacts) {
-            analyzeWriter.println(unusedDelcared)
-          }
+          unusedDeclaredArtifacts.forEach({ final unusedDeclared -> analyzeWriter.println(unusedDeclared) })
           analyzeWriter.println()
 
           analyzeWriter.println("allowedToUseArtifacts:")
-          for (final allowedToUse : allowedToUseArtifacts) {
-            analyzeWriter.println(allowedToUse)
-          }
+          allowedToUseArtifacts.forEach({ final allowedToUse -> analyzeWriter.println(allowedToUse) })
           analyzeWriter.println()
 
           analyzeWriter.println("allowedToDeclareArtifacts:")
-          for (final allowedToDeclare : allowedToDeclareArtifacts) {
-            analyzeWriter.println(allowedToDeclare)
-          }
+          allowedToDeclareArtifacts.forEach({ final allowedToDeclare -> analyzeWriter.println(allowedToDeclare) })
           analyzeWriter.println()
 
           analyzeWriter.println("allArtifacts:")
-          for (final artifact : allArtifacts) {
-            analyzeWriter.println(artifact)
-          }
+          allArtifacts.forEach({ final artifact -> analyzeWriter.println(artifact) })
           analyzeWriter.println()
         }
-      }
     } else {
       logger.info "dependencyArtifacts = $dependencyArtifacts"
       logger.info "allDependencyArtifacts = $allDependencyArtifacts"


### PR DESCRIPTION
For large projects logging to the Gradle logger can cause OutOfMemory
exceptions to occur. Output in excess of 3MiB has been observed.
I added a flag to AnalyzeDependenciesTask called logDependencyInformationToFiles. When that flag is set to true all output is logged into files under build/analyze-dependencies/ instead of to logger.info.