### PR TITLE
Add support for constraints and compileOnly usage

### DIFF
--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
@@ -26,9 +26,6 @@ class AnalyzeDependenciesPlugin implements Plugin<Project> {
           description: 'Analyze project for dependency issues related to main source set.'
       ) {
         require = [
-            project.configurations.compile,
-            project.configurations.findByName('compileOnly'),
-            project.configurations.findByName('provided'),
             project.configurations.findByName('compileClasspath')
         ]
         allowedToUse = [
@@ -48,8 +45,6 @@ class AnalyzeDependenciesPlugin implements Plugin<Project> {
           description: 'Analyze project for dependency issues related to test source set.'
       ) {
         require = [
-            project.configurations.testCompile,
-            project.configurations.findByName('testCompileOnly'),
             project.configurations.findByName('testCompileClasspath')
         ]
         allowedToUse = [


### PR DESCRIPTION
Using `compileClasspath` and `testCompileClasspath` should be sufficient and furthermore it fixes the problem described in #109.
Having a look at the gradle doc https://docs.gradle.org/current/userguide/java_plugin.html it looks like the two configurations mentioned are the one which are supposed to be used by tasks, whereas the others are meant to declare dependencies against them.

I did some manual testing and it looks like everything still works as expected.

I can try to work on some more automated tests if needed.

Thx a lot for providing this plugin!