### PR TITLE
Add relative path sensitivity to classes dirs.

### DIFF
--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
@@ -8,6 +8,8 @@ import org.gradle.api.internal.artifacts.DefaultResolvedArtifact
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 import java.lang.reflect.Method
@@ -18,10 +20,13 @@ class AnalyzeDependenciesTask extends DefaultTask {
   @InputFiles
   List<Configuration> require = []
   @InputFiles
+  @PathSensitive(PathSensitivity.RELATIVE)
   List<Configuration> allowedToUse = []
   @InputFiles
+  @PathSensitive(PathSensitivity.RELATIVE)
   List<Configuration> allowedToDeclare = []
   @InputFiles
+  @PathSensitive(PathSensitivity.RELATIVE)
   FileCollection classesDirs = project.files()
   @OutputFile
   File outputFile = project.file("$project.buildDir/reports/dependency-analyze/$name")
@@ -69,6 +74,7 @@ class AnalyzeDependenciesTask extends DefaultTask {
   }
 
   @InputFiles
+  @PathSensitive(PathSensitivity.RELATIVE)
   FileCollection getAllArtifacts() {
     project.files({
       def files = ProjectDependencyResolver.removeNulls(
@@ -84,6 +90,7 @@ class AnalyzeDependenciesTask extends DefaultTask {
   }
 
   @InputFiles
+  @PathSensitive(PathSensitivity.RELATIVE)
   FileCollection getRequiredFiles() {
     project.files({
       def files = getFirstLevelFiles(require, 'required') -
@@ -94,11 +101,13 @@ class AnalyzeDependenciesTask extends DefaultTask {
   }
 
   @InputFiles
+  @PathSensitive(PathSensitivity.RELATIVE)
   FileCollection getAllowedToUseFiles() {
     getFirstLevelFileCollection(allowedToUse, 'allowed to use')
   }
 
   @InputFiles
+  @PathSensitive(PathSensitivity.RELATIVE)
   FileCollection getAllowedToDeclareFiles() {
     getFirstLevelFileCollection(allowedToDeclare, 'allowed to declare')
   }

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
@@ -7,6 +7,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.artifacts.DefaultResolvedArtifact
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -17,13 +18,11 @@ import java.lang.reflect.Method
 class AnalyzeDependenciesTask extends DefaultTask {
   @Input
   boolean justWarn = false
-  @InputFiles
+  @Internal
   List<Configuration> require = []
-  @InputFiles
-  @PathSensitive(PathSensitivity.RELATIVE)
+  @Internal
   List<Configuration> allowedToUse = []
-  @InputFiles
-  @PathSensitive(PathSensitivity.RELATIVE)
+  @Internal
   List<Configuration> allowedToDeclare = []
   @InputFiles
   @PathSensitive(PathSensitivity.RELATIVE)

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
@@ -5,12 +5,12 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.artifacts.DefaultResolvedArtifact
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.CompileClasspath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 import java.lang.reflect.Method
@@ -25,7 +25,7 @@ class AnalyzeDependenciesTask extends DefaultTask {
   @Internal
   List<Configuration> allowedToDeclare = []
   @InputFiles
-  @PathSensitive(PathSensitivity.RELATIVE)
+  @Classpath
   FileCollection classesDirs = project.files()
   @OutputFile
   File outputFile = project.file("$project.buildDir/reports/dependency-analyze/$name")
@@ -73,7 +73,7 @@ class AnalyzeDependenciesTask extends DefaultTask {
   }
 
   @InputFiles
-  @PathSensitive(PathSensitivity.RELATIVE)
+  @CompileClasspath
   FileCollection getAllArtifacts() {
     project.files({
       def files = ProjectDependencyResolver.removeNulls(
@@ -89,7 +89,7 @@ class AnalyzeDependenciesTask extends DefaultTask {
   }
 
   @InputFiles
-  @PathSensitive(PathSensitivity.RELATIVE)
+  @CompileClasspath
   FileCollection getRequiredFiles() {
     project.files({
       def files = getFirstLevelFiles(require, 'required') -
@@ -100,13 +100,13 @@ class AnalyzeDependenciesTask extends DefaultTask {
   }
 
   @InputFiles
-  @PathSensitive(PathSensitivity.RELATIVE)
+  @CompileClasspath
   FileCollection getAllowedToUseFiles() {
     getFirstLevelFileCollection(allowedToUse, 'allowed to use')
   }
 
   @InputFiles
-  @PathSensitive(PathSensitivity.RELATIVE)
+  @CompileClasspath
   FileCollection getAllowedToDeclareFiles() {
     getFirstLevelFileCollection(allowedToDeclare, 'allowed to declare')
   }


### PR DESCRIPTION
This allows the cache to be relocatable and shared between directories and different machines.
