### PR TITLE
Document minimum version of Gradle required

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ subprojects {
 }
 ```
 
+As of version `1.4.1`, this plugin requires a minimum of Gradle 5.x. If you are stuck on Gradle 4.x, use version `1.4.0`.
+
 # Sample Output
 If the dependency analysis finds issues, it will normally cause the build to fail, and print a list of the issues that were found, similar to the following:
 ```


### PR DESCRIPTION
Starting with version 1.4.1, builds using Gradle 4.x can no longer use
this plugin and need to upgrade to Gradle 5.x. Document this so that
people who want to use this plugin can choose the appropriate version
based on the version of Gradle that they are using.

See #111