### PR TITLE
Allow defining aggregator dependencies in configuration

### DIFF
--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
@@ -5,115 +5,117 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.file.FileCollection
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.*
 
 import java.lang.reflect.Method
 
 class AnalyzeDependenciesTask extends DefaultTask {
-  @Input
-  boolean justWarn = false
-  @InputFiles
-  List<Configuration> require = []
-  @InputFiles
-  List<Configuration> allowedToUse = []
-  @InputFiles
-  List<Configuration> allowedToDeclare = []
-  @InputFiles
-  FileCollection classesDirs = project.files()
-  @OutputFile
-  File outputFile = project.file("$project.buildDir/reports/dependency-analyze/$name")
+    @Input
+    boolean justWarn = false
+    @InputFiles
+    List<Configuration> require = []
+    @Internal
+    Configuration apiHelperConfiguration
+    @Internal
+    String apiConfigurationName = ''
+    @InputFiles
+    List<Configuration> allowedToUse = []
+    @InputFiles
+    List<Configuration> allowedToDeclare = []
+    @InputFiles
+    List<Configuration> allowedAggregatorsToUse = []
+    @InputFiles
+    FileCollection classesDirs = project.files()
+    @OutputFile
+    File outputFile = project.file("$project.buildDir/reports/dependency-analyze/$name")
 
-  AnalyzeDependenciesTask() {
-    def methods = outputs.class.getMethods().grep {Method m -> m.name == 'cacheIf'}
-    if (methods) {
-      outputs.cacheIf({true})
-    }
-  }
-
-  void setClassesDir(File classesDir) {
-    this.classesDirs = project.files(classesDir)
-  }
-
-  @TaskAction
-  def action() {
-    logger.info "Analyzing dependencies of $classesDirs for [require: $require, allowedToUse: $allowedToUse, " +
-        "allowedToDeclare: $allowedToDeclare]"
-    ProjectDependencyAnalysis analysis =
-        new ProjectDependencyResolver(project, require, allowedToUse, allowedToDeclare, classesDirs)
-            .analyzeDependencies()
-    StringBuffer buffer = new StringBuffer()
-    ['usedUndeclaredArtifacts', 'unusedDeclaredArtifacts'].each {section ->
-      def violations = analysis."$section"
-      if (violations) {
-        buffer.append("$section: \n")
-        violations.sort { it.moduleVersion.id.toString() }.each { ResolvedArtifact it ->
-          def clas = it.classifier ? ":$it.classifier" : ""
-          buffer.append(" - $it.moduleVersion.id$clas@$it.extension\n")
+    AnalyzeDependenciesTask() {
+        def methods = outputs.class.getMethods().grep { Method m -> m.name == 'cacheIf' }
+        if (methods) {
+            outputs.cacheIf({ true })
         }
-      }
     }
-    outputFile.parentFile.mkdirs()
-    outputFile.text = buffer.toString()
-    if (buffer) {
-      def message = "Dependency analysis found issues.\n$buffer"
-      if (justWarn) {
-        logger.warn message
-      }
-      else {
-        throw new DependencyAnalysisException(message)
-      }
+
+    void setClassesDir(File classesDir) {
+        this.classesDirs = project.files(classesDir)
     }
-  }
 
-  @InputFiles
-  FileCollection getAllArtifacts() {
-    project.files({
-      def files = ProjectDependencyResolver.removeNulls(
-          ProjectDependencyResolver.removeNulls(require)
-              *.resolvedConfiguration
-              *.firstLevelModuleDependencies
-              *.allModuleArtifacts
-              *.file.flatten() as Set<File>
-      )
-      logger.info "All Artifact Files: $files"
-      files
-    })
-  }
+    @TaskAction
+    def action() {
+        logger.info "Analyzing dependencies of $classesDirs for [require: $require, allowedToUse: $allowedToUse, " +
+                "allowedToDeclare: $allowedToDeclare]"
+        ProjectDependencyAnalysis analysis =
+                new ProjectDependencyResolver(project, require, apiHelperConfiguration, apiConfigurationName, allowedToUse,
+                        allowedToDeclare, classesDirs, allowedAggregatorsToUse).analyzeDependencies()
+        StringBuffer buffer = new StringBuffer()
+        ['usedUndeclaredArtifacts', 'unusedDeclaredArtifacts'].each { section ->
+            def violations = analysis."$section"
+            if (violations) {
+                buffer.append("$section: \n")
+                violations.sort { it.moduleVersion.id.toString() }.each { ResolvedArtifact it ->
+                    def clas = it.classifier ? ":$it.classifier" : ""
+                    buffer.append(" - $it.moduleVersion.id$clas@$it.extension\n")
+                }
+            }
+        }
+        outputFile.parentFile.mkdirs()
+        outputFile.text = buffer.toString()
+        if (buffer) {
+            def message = "Dependency analysis found issues.\n$buffer"
+            if (justWarn) {
+                logger.warn message
+            } else {
+                throw new DependencyAnalysisException(message)
+            }
+        }
+    }
 
-  @InputFiles
-  FileCollection getRequiredFiles() {
-    project.files({
-      def files = getFirstLevelFiles(require, 'required') -
-          getFirstLevelFiles(allowedToUse, 'allowed to use')
-      logger.info  "Actual required files: $files"
-      files
-    })
-  }
+    @InputFiles
+    FileCollection getAllArtifacts() {
+        project.files({
+            def files = ProjectDependencyResolver.removeNulls(
+                    ProjectDependencyResolver.removeNulls(require)
+                            *.resolvedConfiguration
+                            *.firstLevelModuleDependencies
+                            *.allModuleArtifacts
+                            *.file.flatten() as Set<File>
+            )
+            logger.info "All Artifact Files: $files"
+            files
+        })
+    }
 
-  @InputFiles
-  FileCollection getAllowedToUseFiles() {
-    getFirstLevelFileCollection(allowedToUse, 'allowed to use')
-  }
+    @InputFiles
+    FileCollection getRequiredFiles() {
+        project.files({
+            def files = getFirstLevelFiles(require, 'required') -
+                    getFirstLevelFiles(allowedToUse, 'allowed to use')
+            logger.info "Actual required files: $files"
+            files
+        })
+    }
 
-  @InputFiles
-  FileCollection getAllowedToDeclareFiles() {
-    getFirstLevelFileCollection(allowedToDeclare, 'allowed to declare')
-  }
+    @InputFiles
+    FileCollection getAllowedToUseFiles() {
+        getFirstLevelFileCollection(allowedToUse, 'allowed to use')
+    }
 
-  private FileCollection getFirstLevelFileCollection(List<Configuration> configurations, String name) {
-    project.files {getFirstLevelFiles(configurations, name)}
-  }
+    @InputFiles
+    FileCollection getAllowedToDeclareFiles() {
+        getFirstLevelFileCollection(allowedToDeclare, 'allowed to declare')
+    }
 
-  Set<File> getFirstLevelFiles(List<Configuration> configurations, String name) {
-    Set<File> files = ProjectDependencyResolver.removeNulls(
-        ProjectDependencyResolver.getFirstLevelDependencies(
-            ProjectDependencyResolver.removeNulls(configurations)
-        )*.moduleArtifacts*.file.flatten()
-    )
-    logger.info "First level $name files: $files"
-    files
-  }
+    private FileCollection getFirstLevelFileCollection(List<Configuration> configurations, String name) {
+        project.files { getFirstLevelFiles(configurations, name) }
+    }
+
+    Set<File> getFirstLevelFiles(List<Configuration> configurations, String name) {
+        Set<File> files = ProjectDependencyResolver.removeNulls(
+                ProjectDependencyResolver.getFirstLevelDependencies(
+                        ProjectDependencyResolver.removeNulls(configurations)
+                )*.moduleArtifacts*.file.flatten()
+        )
+        logger.info "First level $name files: $files"
+        files
+    }
 }

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/ProjectDependencyResolver.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/ProjectDependencyResolver.groovy
@@ -12,6 +12,7 @@ import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.ResolvedDependency
+import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.logging.Logger
 
 import java.util.concurrent.ConcurrentHashMap
@@ -26,13 +27,21 @@ class ProjectDependencyResolver {
     private final ConcurrentHashMap<File, Set<String>> artifactClassCache
     private final Logger logger
     private final List<Configuration> require
+    private final List<Configuration> api
     private final List<Configuration> allowedToUse
     private final List<Configuration> allowedToDeclare
     private final Iterable<File> classesDirs
+    private final Map<ResolvedArtifact, Set<ResolvedArtifact>> aggregatorsWithDependencies
+    private final List<Configuration> allowedAggregatorsToUse
 
-    ProjectDependencyResolver(final Project project, final List<Configuration> require,
-                              final List<Configuration> allowedToUse, final List<Configuration> allowedToDeclare,
-                              final Iterable<File> classesDirs) {
+    ProjectDependencyResolver(final Project project,
+                              final List<Configuration> require,
+                              final Configuration apiHelperConfiguration,
+                              final String apiConfigurationName,
+                              final List<Configuration> allowedToUse,
+                              final List<Configuration> allowedToDeclare,
+                              final Iterable<File> classesDirs,
+                              final List<Configuration> allowedAggregatorsToUse) {
         try {
             this.artifactClassCache =
                     project.rootProject.extensions.getByName(CACHE_NAME) as ConcurrentHashMap<File, Set<String>>
@@ -42,9 +51,12 @@ class ProjectDependencyResolver {
         }
         this.logger = project.logger
         this.require = removeNulls(require) as List
+        this.api = configureApiHelperConfiguration(apiHelperConfiguration, project, apiConfigurationName)
+        this.allowedAggregatorsToUse = removeNulls(allowedAggregatorsToUse) as List
         this.allowedToUse = removeNulls(allowedToUse) as List
         this.allowedToDeclare = removeNulls(allowedToDeclare) as List
         this.classesDirs = classesDirs
+        this.aggregatorsWithDependencies = getAggregatorsMapping()
     }
 
     static <T> Collection<T> removeNulls(final Collection<T> collection) {
@@ -98,21 +110,51 @@ class ProjectDependencyResolver {
                 flatten() as Set<ResolvedArtifact>
         logger.info "allowedToDeclareArtifacts = $allowedToDeclareArtifacts"
 
-        Set<ResolvedArtifact> allArtifacts = (((require
-                .collect { it.resolvedConfiguration }
-                .collect { it.firstLevelModuleDependencies }.flatten()) as Set<ResolvedDependency>)
-                .collect { it.allModuleArtifacts }.flatten()) as Set<ResolvedArtifact>
+        Set<ResolvedArtifact> allArtifacts = resolveArtifacts(require)
 
         logger.info "allArtifacts = $allArtifacts"
 
         def usedDeclared = allArtifacts.findAll { ResolvedArtifact artifact -> artifact.file in usedDeclaredArtifacts }
         def usedUndeclared = allArtifacts.findAll { ResolvedArtifact artifact -> artifact.file in usedUndeclaredArtifacts }
         if (allowedToUseArtifacts) {
-            usedUndeclared -= allowedToUseArtifacts
+            def allowedToUseComponentIdentifiers = allowedToUseArtifacts.collect { it.id.componentIdentifier }
+            usedUndeclared.removeAll { allowedToUseComponentIdentifiers.contains(it.id.componentIdentifier) }
         }
         def unusedDeclared = allArtifacts.findAll { ResolvedArtifact artifact -> artifact.file in unusedDeclaredArtifacts }
         if (allowedToDeclareArtifacts) {
-            unusedDeclared -= allowedToDeclareArtifacts
+            def allowedToDeclareComponentIdentifiers = allowedToDeclareArtifacts.collect { it.id.componentIdentifier }
+            unusedDeclared.removeAll { allowedToDeclareComponentIdentifiers.contains(it.id.componentIdentifier) }
+        }
+
+        if (!aggregatorsWithDependencies.isEmpty()) {
+            def usedIdentifiers = (requiredDependencies.collect { it.allModuleArtifacts }.flatten() as Set<ResolvedArtifact>)
+                    .collect { it.id }
+                    .collect { it.componentIdentifier }
+            def aggregatorUsage = used(usedIdentifiers, usedArtifacts).groupBy { it.value.isEmpty() }
+            if (aggregatorUsage.containsKey(true)) {
+                def unusedAggregatorArtifacts = aggregatorUsage.get(true).keySet() as Set<ResolvedArtifact>
+                unusedDeclared += unusedAggregatorArtifacts.intersect(requiredDeps.collect { it.allModuleArtifacts }.flatten() as Set<ResolvedArtifact>)
+            }
+            if (aggregatorUsage.containsKey(false)) {
+                def usedAggregator = aggregatorUsage.get(false)
+                def usedAggregatorDependencies = usedAggregator.keySet()
+                usedDeclared += usedAggregatorDependencies.intersect(unusedDeclared, { ResolvedArtifact a, ResolvedArtifact b ->
+                    a.id.componentIdentifier == b.id.componentIdentifier ? 0 : a.id.componentIdentifier.displayName <=> b.id.componentIdentifier.displayName
+                } as Comparator<ResolvedArtifact>)
+
+                def flatten = usedAggregator.values().flatten().collect({ it -> (ResolvedArtifact) it })
+                unusedDeclared += usedDeclared.intersect(flatten)
+                def usedAggregatorComponentIdentifiers = usedAggregatorDependencies.collect { it.id.componentIdentifier } as Set<ResolvedArtifact>
+                unusedDeclared.removeAll { usedAggregatorComponentIdentifiers.contains(it.id.componentIdentifier) }
+                def apiComponentIdentifiers = (getFirstLevelDependencies(api).collect { it.allModuleArtifacts }.flatten() as Set<ResolvedArtifact>)
+                        .collect { it.id.componentIdentifier } as Set<ComponentIdentifier>
+                unusedDeclared.removeAll { apiComponentIdentifiers.contains(it.id.componentIdentifier) }
+
+                usedUndeclared -= usedAggregatorDependencies.collect { aggregatorsWithDependencies.get(it) }.flatten()
+                def usedDeclaredComponentIdentifiers = usedDeclared.collect { it.id.componentIdentifier } as Set<ResolvedArtifact>
+                usedUndeclared += usedAggregatorDependencies.findAll { !usedDeclaredComponentIdentifiers.contains(it.id.componentIdentifier) }
+                usedUndeclared.removeIf { allowedToUseArtifacts.contains(it) && aggregatorsWithDependencies.keySet().contains(it) }
+            }
         }
 
         return new ProjectDependencyAnalysis(
@@ -205,5 +247,59 @@ class ProjectDependencyResolver {
             }
         }
         return usedArtifacts
+    }
+
+    private Set<ResolvedArtifact> resolveArtifacts(List<Configuration> configurations) {
+        Set<ResolvedArtifact> allArtifacts = (((configurations
+                .collect { it.resolvedConfiguration }
+                .collect { it.firstLevelModuleDependencies }.flatten()) as Set<ResolvedDependency>)
+                .collect { it.allModuleArtifacts }.flatten()) as Set<ResolvedArtifact>
+        allArtifacts
+    }
+
+    private List<Configuration> configureApiHelperConfiguration(Configuration apiHelperConfiguration, Project project, String apiConfigurationName) {
+        final def apiConfiguration = [project.configurations.findByName(apiConfigurationName)]
+        apiHelperConfiguration.extendsFrom(removeNulls(apiConfiguration) as Configuration[])
+        [apiHelperConfiguration]
+    }
+
+    private Map<ResolvedArtifact, Set<ResolvedArtifact>> getAggregatorsMapping() {
+        if (!allowedAggregatorsToUse.empty) {
+            def resolvedArtifacts = resolveArtifacts(allowedAggregatorsToUse).collectEntries { [it.moduleVersion.toString(), it] }
+            def dependencies = getFirstLevelDependencies(allowedAggregatorsToUse)
+            dependencies.collectEntries({ it ->
+                resolvedArtifacts.containsKey(it.name) ? [resolvedArtifacts.get(it.name), it.allModuleArtifacts as Set<ResolvedArtifact>] : [:]
+            })
+        } else {
+            [:]
+        }
+    }
+
+    private Map<ResolvedArtifact, Collection<ResolvedArtifact>> used(List<ComponentIdentifier> allDependencyArtifacts, Set<File> usedArtifacts) {
+        def usedAggregators = new LinkedHashMap<ResolvedArtifact, Collection<ResolvedArtifact>>()
+
+        aggregatorsWithDependencies.each {
+            if (allDependencyArtifacts.contains(it.key.id.componentIdentifier)) {
+                def filesForAggregator = it.value.collect({ it.file })
+                def disjoint = filesForAggregator.intersect(usedArtifacts)
+                usedAggregators.put(it.key, it.value.findAll { disjoint.contains(it.file) })
+            }
+        }
+
+        removeDuplicates(usedAggregators)
+    }
+
+    private Map<ResolvedArtifact, Collection<ResolvedArtifact>> removeDuplicates(Map<ResolvedArtifact, Collection<ResolvedArtifact>> usedAggregators) {
+        def aggregatorsSortedByDependencies = usedAggregators.sort { l, r ->
+            l.value.size() <=> r.value.size() ?: aggregatorsWithDependencies.get(r.key).size() <=> aggregatorsWithDependencies.get(l.key).size()
+        }
+
+        def aggregatorArtifactAlreadySeen = [] as Set
+        aggregatorsSortedByDependencies.removeAll {
+            aggregatorArtifactAlreadySeen.add(it.key)
+            aggregatorsSortedByDependencies.any { it2 -> !aggregatorArtifactAlreadySeen.contains(it2.key) && it2.value.containsAll(it.value) }
+        }
+        logger.debug "used aggregators: $aggregatorsSortedByDependencies.keySet()"
+        return aggregatorsSortedByDependencies
     }
 }

--- a/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginAggregatorSpec.groovy
+++ b/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginAggregatorSpec.groovy
@@ -1,0 +1,373 @@
+package ca.cutterslade.gradle.analyze
+
+import ca.cutterslade.gradle.analyze.helper.GradleDependency
+import ca.cutterslade.gradle.analyze.helper.GroovyClass
+import org.gradle.testkit.runner.BuildResult
+import spock.lang.Unroll
+
+class AnalyzeDependenciesPluginAggregatorSpec extends AnalyzeDependenciesPluginBaseSpec {
+    @Unroll
+    def "aggregator dependency declared in config and used in build with #configuration results in #expectedResult"() {
+        setup:
+        rootProject()
+                .withMavenRepositories()
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', id: 'org.springframework.boot:spring-boot-starter:2.3.6.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'compile', id: 'org.springframework.boot:spring-boot-starter:2.3.6.RELEASE'))
+                .withMainClass(new GroovyClass('Main')
+                        .usesClass('Dependent')
+                        .usesClass('org.springframework.context.annotation.ComponentScan')
+                        .usesClass('org.springframework.beans.factory.annotation.Autowired')
+                )
+                .withSubProject(subProject("dependent")
+                        .withMainClass(new GroovyClass("Dependent")))
+                .withDependency(new GradleDependency(configuration: configuration, project: "dependent"))
+                .create(projectDir.getRoot())
+
+        when:
+        BuildResult result = buildGradleProject(expectedResult)
+
+        then:
+        assertBuildResult(result, expectedResult)
+
+        where:
+        configuration    | expectedResult
+        "compile"        | SUCCESS
+        "implementation" | SUCCESS
+        "compileOnly"    | SUCCESS
+        "runtimeOnly"    | BUILD_FAILURE
+    }
+
+    @Unroll
+    def "aggregator dependency not declared in config and used in build should report unused aggregator with #configuration results in #expectedResult"() {
+        setup:
+        rootProject()
+                .withMavenRepositories()
+                .withDependency(new GradleDependency(configuration: 'compile', id: 'org.springframework.boot:spring-boot-starter:2.3.6.RELEASE'))
+                .withMainClass(new GroovyClass('Main')
+                        .usesClass('Dependent')
+                        .usesClass('org.springframework.context.annotation.ComponentScan')
+                        .usesClass('org.springframework.beans.factory.annotation.Autowired')
+                )
+                .withSubProject(subProject("dependent")
+                        .withMainClass(new GroovyClass("Dependent")))
+                .withDependency(new GradleDependency(configuration: configuration, project: "dependent"))
+                .create(projectDir.getRoot())
+
+        when:
+        BuildResult result = buildGradleProject(expectedResult)
+
+        then:
+        assertBuildResult(result, expectedResult, usedUndeclaredArtifacts, unusedDeclaredArtifacts)
+
+        where:
+        configuration    | expectedResult | usedUndeclaredArtifacts                                                                                          | unusedDeclaredArtifacts
+        "compile"        | VIOLATIONS     | ["org.springframework:spring-beans:5.2.11.RELEASE@jar", "org.springframework:spring-context:5.2.11.RELEASE@jar"] | ["org.springframework.boot:spring-boot-starter:2.3.6.RELEASE@jar"]
+        "implementation" | VIOLATIONS     | ["org.springframework:spring-beans:5.2.11.RELEASE@jar", "org.springframework:spring-context:5.2.11.RELEASE@jar"] | ["org.springframework.boot:spring-boot-starter:2.3.6.RELEASE@jar"]
+        "compileOnly"    | VIOLATIONS     | ["org.springframework:spring-beans:5.2.11.RELEASE@jar", "org.springframework:spring-context:5.2.11.RELEASE@jar"] | ["org.springframework.boot:spring-boot-starter:2.3.6.RELEASE@jar"]
+        "runtimeOnly"    | BUILD_FAILURE  | []                                                                                                               | []
+    }
+
+    @Unroll
+    def "aggregator dependency declared in config and not used in build with dedicated dependency should report missing dependency with #configuration results in #expectedResult"() {
+        setup:
+        rootProject()
+                .withMavenRepositories()
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', id: 'org.springframework.boot:spring-boot-starter:2.3.6.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'compile', id: 'org.springframework:spring-context:5.2.11.RELEASE'))
+                .withMainClass(new GroovyClass('Main')
+                        .usesClass('Dependent')
+                        .usesClass('org.springframework.context.annotation.ComponentScan')
+                        .usesClass('org.springframework.beans.factory.annotation.Autowired')
+                )
+                .withSubProject(subProject("dependent")
+                        .withMainClass(new GroovyClass("Dependent")))
+                .withDependency(new GradleDependency(configuration: configuration, project: "dependent"))
+                .create(projectDir.getRoot())
+
+        when:
+        BuildResult result = buildGradleProject(expectedResult)
+
+        then:
+        assertBuildResult(result, expectedResult, usedUndeclaredArtifacts, unusedDeclaredArtifacts)
+
+        where:
+        configuration    | expectedResult | usedUndeclaredArtifacts                                 | unusedDeclaredArtifacts
+        "compile"        | VIOLATIONS     | ["org.springframework:spring-beans:5.2.11.RELEASE@jar"] | []
+        "implementation" | VIOLATIONS     | ["org.springframework:spring-beans:5.2.11.RELEASE@jar"] | []
+        "compileOnly"    | VIOLATIONS     | ["org.springframework:spring-beans:5.2.11.RELEASE@jar"] | []
+        "runtimeOnly"    | BUILD_FAILURE  | []                                                      | []
+    }
+
+    @Unroll
+    def "aggregator dependency declared in config and used in build together with dedicated dependency should report explicit dependency as unused with #configuration results in #expectedResult"() {
+        setup:
+        rootProject()
+                .withMavenRepositories()
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', id: 'org.springframework.boot:spring-boot-starter:2.3.6.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'compile', id: 'org.springframework:spring-context:5.2.11.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'compile', id: 'org.springframework.boot:spring-boot-starter:2.3.6.RELEASE'))
+                .withMainClass(new GroovyClass('Main')
+                        .usesClass('Dependent')
+                        .usesClass('org.springframework.context.annotation.ComponentScan')
+                        .usesClass('org.springframework.beans.factory.annotation.Autowired')
+                )
+                .withSubProject(subProject("dependent")
+                        .withMainClass(new GroovyClass("Dependent")))
+                .withDependency(new GradleDependency(configuration: configuration, project: "dependent"))
+                .create(projectDir.getRoot())
+
+        when:
+        BuildResult result = buildGradleProject(expectedResult)
+
+        then:
+        assertBuildResult(result, expectedResult, usedUndeclaredArtifacts, unusedDeclaredArtifacts)
+
+        where:
+        configuration    | expectedResult | usedUndeclaredArtifacts | unusedDeclaredArtifacts
+        "compile"        | VIOLATIONS     | []                      | ["org.springframework:spring-context:5.2.11.RELEASE@jar"]
+        "implementation" | VIOLATIONS     | []                      | ["org.springframework:spring-context:5.2.11.RELEASE@jar"]
+        "compileOnly"    | VIOLATIONS     | []                      | ["org.springframework:spring-context:5.2.11.RELEASE@jar"]
+        "runtimeOnly"    | BUILD_FAILURE  | []                      | []
+    }
+
+    @Unroll
+    def "multiple aggregator dependencies declared and dependency available in both aggregators should choose the aggregator with less dependencies and report other as unused results in #expectedResult"() {
+        setup:
+        rootProject()
+                .withMavenRepositories()
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', id: 'org.springframework.boot:spring-boot-starter:2.3.6.RELEASE'))
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', id: 'org.springframework.boot:spring-boot-starter-web:2.3.6.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'compile', id: 'org.springframework.boot:spring-boot-starter:2.3.6.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'compile', id: 'org.springframework.boot:spring-boot-starter-web:2.3.6.RELEASE'))
+                .withMainClass(new GroovyClass('Main')
+                        .usesClass('org.springframework.context.annotation.ComponentScan')
+                        .usesClass('org.springframework.beans.factory.annotation.Autowired')
+                )
+                .create(projectDir.getRoot())
+
+        when:
+        BuildResult result = buildGradleProject(expectedResult)
+
+        then:
+        assertBuildResult(result, expectedResult, usedUndeclaredArtifacts, unusedDeclaredArtifacts)
+
+        where:
+        expectedResult | usedUndeclaredArtifacts | unusedDeclaredArtifacts
+        VIOLATIONS     | []                      | ["org.springframework.boot:spring-boot-starter-web:2.3.6.RELEASE@jar"]
+    }
+
+    @Unroll
+    def "multiple aggregator dependencies declared in config and dependency available in both aggregators plus one additional should choose aggregators with less dependencies results in #expectedResult"() {
+        setup:
+        rootProject()
+                .withMavenRepositories()
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', id: 'org.springframework.boot:spring-boot-starter:2.3.6.RELEASE'))
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', id: 'org.springframework.boot:spring-boot-starter-jdbc:2.3.6.RELEASE'))
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', id: 'org.springframework.boot:spring-boot-starter-web:2.3.6.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'compile', id: 'org.springframework.boot:spring-boot-starter:2.3.6.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'compile', id: 'org.springframework.boot:spring-boot-starter-jdbc:2.3.6.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'compile', id: 'org.springframework.boot:spring-boot-starter-web:2.3.6.RELEASE'))
+                .withMainClass(new GroovyClass('Main')
+                        .usesClass('org.springframework.context.annotation.ComponentScan')
+                        .usesClass('org.springframework.beans.factory.annotation.Autowired')
+                        .usesClass('org.springframework.jdbc.BadSqlGrammarException')
+                )
+                .create(projectDir.getRoot())
+
+        when:
+        BuildResult result = buildGradleProject(expectedResult)
+
+        then:
+        assertBuildResult(result, expectedResult, usedUndeclaredArtifacts, unusedDeclaredArtifacts)
+
+        where:
+        expectedResult | usedUndeclaredArtifacts | unusedDeclaredArtifacts
+        VIOLATIONS     | []                      | ["org.springframework.boot:spring-boot-starter-web:2.3.6.RELEASE@jar", "org.springframework.boot:spring-boot-starter:2.3.6.RELEASE@jar"]
+    }
+
+    @Unroll
+    def "multiple aggregator dependencies declared in config and dependency available in both aggregators plus one additional should keep only used distinct aggregators results in #expectedResult"() {
+        setup:
+        rootProject()
+                .withMavenRepositories()
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', id: 'org.springframework.boot:spring-boot-starter:2.3.6.RELEASE'))
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', id: 'org.springframework.boot:spring-boot-starter-jdbc:2.3.6.RELEASE'))
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', id: 'org.springframework.boot:spring-boot-starter-web:2.3.6.RELEASE'))
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', id: 'org.springframework.boot:spring-boot-starter-validation:2.3.6.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'compile', id: 'org.springframework.boot:spring-boot-starter:2.3.6.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'compile', id: 'org.springframework.boot:spring-boot-starter-jdbc:2.3.6.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'compile', id: 'org.springframework.boot:spring-boot-starter-web:2.3.6.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'compile', id: 'org.springframework.boot:spring-boot-starter-validation:2.3.6.RELEASE'))
+                .withMainClass(new GroovyClass('Main')
+                        .usesClass('org.springframework.context.annotation.ComponentScan')
+                        .usesClass('org.springframework.beans.factory.annotation.Autowired')
+                        .usesClass('org.springframework.jdbc.BadSqlGrammarException')
+                        .usesClass('org.springframework.web.bind.annotation.RestController')
+                        .usesClass('javax.validation.ConstraintValidator')
+                )
+                .create(projectDir.getRoot())
+
+        when:
+        BuildResult result = buildGradleProject(expectedResult)
+
+        then:
+        assertBuildResult(result, expectedResult, usedUndeclaredArtifacts, unusedDeclaredArtifacts)
+
+        where:
+        expectedResult | usedUndeclaredArtifacts | unusedDeclaredArtifacts
+        VIOLATIONS     | []                      | ["org.springframework.boot:spring-boot-starter:2.3.6.RELEASE@jar"]
+    }
+
+    @Unroll
+    def "multiple aggregator dependencies declared in config and another aggregator is smaller results in #expectedResult"() {
+        setup:
+        rootProject()
+                .withMavenRepositories()
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', id: 'org.springframework.boot:spring-boot-starter-json:2.3.6.RELEASE'))
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', id: 'org.springframework.boot:spring-boot-starter-web:2.3.6.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'compile', id: 'org.springframework.boot:spring-boot-starter:2.3.6.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'compile', id: 'org.springframework.boot:spring-boot-starter-web:2.3.6.RELEASE'))
+                .withMainClass(new GroovyClass('Main')
+                        .usesClass('com.fasterxml.jackson.databind.ObjectMapper')
+                        .usesClass('org.springframework.beans.factory.annotation.Autowired')
+                        .usesClass('org.springframework.web.context.request.RequestContextHolder')
+                )
+                .create(projectDir.getRoot())
+
+        when:
+        BuildResult result = buildGradleProject(expectedResult)
+
+        then:
+        assertBuildResult(result, expectedResult, usedUndeclaredArtifacts, unusedDeclaredArtifacts)
+
+        where:
+        expectedResult | usedUndeclaredArtifacts                                                 | unusedDeclaredArtifacts
+        VIOLATIONS     | ["org.springframework.boot:spring-boot-starter-json:2.3.6.RELEASE@jar"] | ["org.springframework.boot:spring-boot-starter-web:2.3.6.RELEASE@jar", "org.springframework.boot:spring-boot-starter:2.3.6.RELEASE@jar"]
+    }
+
+    @Unroll
+    def "aggregator from project results in #expectedResult"() {
+        setup:
+        rootProject()
+                .withMavenRepositories()
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', project: 'bom'))
+                .withDependency(new GradleDependency(configuration: 'compile', project: 'bom'))
+                .withDependency(new GradleDependency(configuration: 'compile', project: 'dependent'))
+                .withSubProject(subProject('bom')
+                        .withDependency(new GradleDependency(configuration: 'compile', project: 'dependent'))
+                )
+                .withSubProject(subProject("dependent")
+                        .withMainClass(new GroovyClass("Dependent"))
+                )
+                .withMainClass(new GroovyClass("Main").usesClass("Dependent"))
+                .create(projectDir.getRoot())
+
+        when:
+        BuildResult result = buildGradleProject(expectedResult)
+
+        then:
+        assertBuildResult(result, expectedResult, usedUndeclaredArtifacts, unusedDeclaredArtifacts)
+
+        where:
+        expectedResult | usedUndeclaredArtifacts | unusedDeclaredArtifacts
+        VIOLATIONS     | []                      | ["project:dependent:unspecified@jar"]
+    }
+
+    def "aggregator from project with used jar dependency"() {
+        setup:
+        rootProject()
+                .withMavenRepositories()
+                .withAggregator(new GradleDependency(configuration: 'permitTestAggregatorUse', project: 'spring'))
+                .withSubProject(subProject('spring')
+                        .withPlugin('java-library')
+                        .withDependency(new GradleDependency(configuration: 'api', id: 'org.springframework:spring-beans:5.2.11.RELEASE'))
+                        .withDependency(new GradleDependency(configuration: 'api', id: 'org.springframework:spring-context:5.2.11.RELEASE'))
+
+                )
+                .withSubProject(subProject('tests')
+                        .withMavenRepositories()
+                        .withDependency(new GradleDependency(configuration: 'testImplementation', project: 'spring'))
+                        .withTestClass(new GroovyClass("Main")
+                                .usesClass('org.springframework.context.annotation.ComponentScan'))
+                )
+                .create(projectDir.getRoot())
+
+        when:
+        BuildResult result = gradleProject().build()
+
+        then:
+        assertBuildSuccess(result)
+    }
+
+    def "aggregator with api and implementation from project with used jar dependency"() {
+        setup:
+        rootProject()
+                .withMavenRepositories()
+                .withAggregator(new GradleDependency(configuration: 'permitTestAggregatorUse', project: 'spring'))
+                .withSubProject(subProject('spring')
+                        .withPlugin('java-library')
+                        .withMavenRepositories()
+                        .withDependency(new GradleDependency(configuration: 'api', id: 'org.apache.commons:commons-collections4:4.4'))
+                        .withDependency(new GradleDependency(configuration: 'implementation', id: 'org.springframework:spring-context:5.2.11.RELEASE'))
+                )
+                .withSubProject(subProject('tests')
+                        .withMavenRepositories()
+                        .withDependency(new GradleDependency(configuration: 'testImplementation', project: 'spring'))
+                        .withDependency(new GradleDependency(configuration: 'testImplementation', id: 'org.springframework:spring-aop:5.2.11.RELEASE'))
+                        .withTestClass(new GroovyClass("Main")
+                                .usesClass('org.springframework.aop.Advisor')
+                                .usesClass('org.apache.commons.collections4.BidiMap'))
+                )
+                .create(projectDir.getRoot())
+
+        when:
+        BuildResult result = gradleProject().build()
+
+        then:
+        assertBuildSuccess(result)
+    }
+
+    def "aggregator with implementation dependency and additional overlapping api dependency"() {
+        setup:
+        rootProject()
+                .withMavenRepositories()
+                .withPlugin('java-library')
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', id: 'org.springframework.boot:spring-boot-starter-web:2.3.6.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'api', id: 'org.springframework:spring-web:5.2.11.RELEASE'))
+                .withDependency(new GradleDependency(configuration: 'implementation', id: 'org.springframework.boot:spring-boot-starter-web:2.3.6.RELEASE'))
+                .withMainClass(new GroovyClass("Main")
+                        .usesClass('org.springframework.beans.factory.annotation.Autowired')
+                        .usesClass('org.springframework.web.context.request.RequestContextHolder'))
+                .create(projectDir.getRoot())
+
+        when:
+        BuildResult result = gradleProject().build()
+
+        then:
+        assertBuildSuccess(result)
+    }
+
+    def "aggregator with implementation dependency and additional overlapping api dependency when versions managed by platform"() {
+        setup:
+        rootProject()
+                .withMavenRepositories()
+                .withSubProject(platformProject('platform')
+                        .withDependency(new GradleDependency(configuration: 'api', reference: 'enforcedPlatform("org.springframework.boot:spring-boot-dependencies:2.3.6.RELEASE")'))
+                )
+                .withPlugin('java-library')
+                .withAggregator(new GradleDependency(configuration: 'permitAggregatorUse', id: 'org.springframework.boot:spring-boot-starter-web'))
+                .withDependency(new GradleDependency(configuration: 'api', id: 'org.springframework:spring-web'))
+                .withDependency(new GradleDependency(configuration: 'implementation', id: 'org.springframework.boot:spring-boot-starter-web'))
+                .withMainClass(new GroovyClass("Main")
+                        .usesClass('org.springframework.beans.factory.annotation.Autowired')
+                        .usesClass('org.springframework.web.context.request.RequestContextHolder'))
+                .applyPlatformConfiguration()
+                .create(projectDir.getRoot())
+
+        when:
+        BuildResult result = gradleProject().build()
+
+        then:
+        assertBuildSuccess(result)
+    }
+}

--- a/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginBaseSpec.groovy
+++ b/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginBaseSpec.groovy
@@ -26,7 +26,7 @@ abstract class AnalyzeDependenciesPluginBaseSpec extends Specification {
                 .withGradleDependency('implementation')
     }
 
-    private static GradleProject platformProject(String name) {
+    protected static GradleProject platformProject(String name) {
         new GradleProject(name)
                 .withPlugin('java-platform')
     }
@@ -65,7 +65,10 @@ abstract class AnalyzeDependenciesPluginBaseSpec extends Specification {
         return project.buildAndFail()
     }
 
-    protected static void assertBuildResult(BuildResult result, String expectedResult, String[] usedUndeclaredArtifacts = [], String[] unusedDeclaredArtifacts = []) {
+    protected static void assertBuildResult(BuildResult result,
+                                            String expectedResult,
+                                            List<String> usedUndeclaredArtifacts = [],
+                                            List<String> unusedDeclaredArtifacts = []) {
         if (expectedResult == SUCCESS) {
             if (result.task(':build') == null) {
                 throw new SpockAssertionError("Build task not run: \n${result.getOutput()}")
@@ -83,11 +86,11 @@ abstract class AnalyzeDependenciesPluginBaseSpec extends Specification {
             assert result.task(':compileTestGroovy').getOutcome() == TaskOutcome.FAILED
         } else if (expectedResult == VIOLATIONS) {
             def violations = new StringBuilder('> Dependency analysis found issues.\n')
-            if (usedUndeclaredArtifacts?.length > 0) {
+            if (!usedUndeclaredArtifacts.empty) {
                 violations.append('  usedUndeclaredArtifacts: \n')
                 usedUndeclaredArtifacts.each { violations.append("   - ${it}\n") }
             }
-            if (unusedDeclaredArtifacts?.length > 0) {
+            if (!unusedDeclaredArtifacts.empty) {
                 violations.append('  unusedDeclaredArtifacts: \n')
                 unusedDeclaredArtifacts.each { violations.append("   - ${it}\n") }
             }

--- a/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginGradleSpec.groovy
+++ b/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginGradleSpec.groovy
@@ -76,8 +76,8 @@ class AnalyzeDependenciesPluginGradleSpec extends AnalyzeDependenciesPluginBaseS
 
     def determineMinorVersions(String minVersion, String maxVersion, String expectedResult) {
         try {
-            def serviceUrl = new URL("https://services.gradle.org/versions/all");
-            def versions = new ObjectMapper().readValue(serviceUrl, JsonNode.class);
+            def serviceUrl = new URL("https://services.gradle.org/versions/all")
+            def versions = new ObjectMapper().readValue(serviceUrl, JsonNode.class)
             def minGradleVersion = GradleVersion.version(minVersion)
             def maxGradleVersion = GradleVersion.version(maxVersion)
 
@@ -94,14 +94,14 @@ class AnalyzeDependenciesPluginGradleSpec extends AnalyzeDependenciesPluginBaseS
                     }.collect { k, v -> v.sort().last() }
                     .collect { it -> new Tuple2(it, expectedResult) }
         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            throw new UncheckedIOException(e)
         }
     }
 
     static int ordinalIndexOf(String str, String subStr, int n) {
-        int pos = -1;
+        int pos = -1
         while (true) {
-            def newPos = str.indexOf(subStr, pos + 1);
+            def newPos = str.indexOf(subStr, pos + 1)
             if (newPos == -1) {
                 pos = -1
                 break
@@ -112,6 +112,6 @@ class AnalyzeDependenciesPluginGradleSpec extends AnalyzeDependenciesPluginBaseS
                 }
             }
         }
-        pos;
+        pos
     }
 }

--- a/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginJavaTestFixturesSpec.groovy
+++ b/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginJavaTestFixturesSpec.groovy
@@ -53,7 +53,7 @@ class AnalyzeDependenciesPluginJavaTestFixturesSpec extends AnalyzeDependenciesP
         assertBuildSuccess(result)
     }
 
-    def 'project with test fixture class and main class from different module is not used results in failure'(String expectedResult, String[] usedUndeclaredArtifacts, String[] unusedDeclaredArtifacts) {
+    def 'project with test fixture class and main class from different module is not used results in failure'() {
         setup:
         rootProject()
                 .withPlugin('java-test-fixtures')

--- a/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginSpec.groovy
+++ b/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginSpec.groovy
@@ -45,7 +45,7 @@ class AnalyzeDependenciesPluginSpec extends AnalyzeDependenciesPluginBaseSpec {
     }
 
     @Unroll
-    def 'used transient main dependency declared with #configuration results in #expectedResult'(String configuration, String expectedResult, String[] usedUndeclaredArtifacts, String[] unusedDeclaredArtifacts) {
+    def 'used transient main dependency declared with #configuration results in #expectedResult'() {
         setup:
         rootProject()
                 .withMainClass(new GroovyClass('Main').usesClass('Transient'))
@@ -71,7 +71,7 @@ class AnalyzeDependenciesPluginSpec extends AnalyzeDependenciesPluginBaseSpec {
     }
 
     @Unroll
-    def 'unused main dependency declared with #configuration results in #expectedResult'(String configuration, String expectedResult, String[] usedUndeclaredArtifacts, String[] unusedDeclaredArtifacts) {
+    def 'unused main dependency declared with #configuration results in #expectedResult'() {
         setup:
         rootProject()
                 .withMainClass(new GroovyClass('Main'))
@@ -120,7 +120,7 @@ class AnalyzeDependenciesPluginSpec extends AnalyzeDependenciesPluginBaseSpec {
     }
 
     @Unroll
-    def 'unused test dependency declared with #configuration results in #expectedResult'(String configuration, String expectedResult, String[] usedUndeclaredArtifacts, String[] unusedDeclaredArtifacts) {
+    def 'unused test dependency declared with #configuration results in #expectedResult'() {
         setup:
         rootProject()
                 .withMainClass(new GroovyClass('Main'))
@@ -145,7 +145,7 @@ class AnalyzeDependenciesPluginSpec extends AnalyzeDependenciesPluginBaseSpec {
     }
 
     @Unroll
-    def 'used transient test dependency declared with #configuration results in #expectedResult'(String configuration, String expectedResult, String[] usedUndeclaredArtifacts, String[] unusedDeclaredArtifacts) {
+    def 'used transient test dependency declared with #configuration results in #expectedResult'() {
         setup:
         rootProject()
                 .withMainClass(new GroovyClass('Main'))


### PR DESCRIPTION
By defining a list of aggregator dependencies for the task the following will now happen:
- when an aggregator dependency includes a previously used but undeclared dependency it will be removed from the used and undeclared list and also added to the used declared list
- when an aggregator dependency does not contain any dependencies that are used it will be added to the unused declared dependency list

in that way, it Is possible to define something like a spring-boot-starter dependency as an aggregator dependency which will be used to "clean up" the result

Closes #122