### PR TITLE
Adding a test to verify current state of constant detection capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ Execution failed for task ':analyzeClassesDependencies'.
    - net.sf.json-lib:json-lib:2.3:jdk15@jar
 ```
 
+# Restrictions
+This plugin can not properly detect the following use cases and will issue a warning about a problematic dependency declaration.
+1. When a constant is used inside the code that is located in a dependency, and it is the only usage of anything from that dependency the plugin *might* report a problem about an unused dependency
+2. When a constant is used as a value in an annotation is located in a dependency, and it is the only usage of anything from that dependency the plugin is not able to detect that usage as in that case all references to the constant are erased by the java compiler
+3. When a class hierarchy is in place across multiple gradle subprojects or different dependencies the plugin is not able to detect this kind of hierarchies as the byte code only contains references to "direct" classes that are used
+4. When an exception is part of a method signature and this exception is in a dependency and this is the only used class from that dependency the class invoking this method and not using this exception but throwing a more general one the exception usage will not be detected as it is not part of the byte code
+5. Annotations with `@Retention(SOURCE)` are not part of the byte code, so these usages will not be detected the plugin (e.g. `@Generated` from `jakarta-annotation-api` or `javax.annotation-api`)
+
+In these situations a `permit*UnusedDeclared` must be added to not trigger a build failure or warning by this plugin
+
 # Tasks
 This plugin will add the following tasks to your project: `analyzeClassesDependencies`, `analyzeTestClassesDependencies`, and `analyzeDependencies`.
 ## analyzeClassesDependencies

--- a/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginConstantsSpec.groovy
+++ b/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginConstantsSpec.groovy
@@ -1,0 +1,37 @@
+package ca.cutterslade.gradle.analyze
+
+import ca.cutterslade.gradle.analyze.helper.GradleDependency
+import ca.cutterslade.gradle.analyze.helper.GroovyClass
+
+class AnalyzeDependenciesPluginConstantsSpec extends AnalyzeDependenciesPluginBaseSpec {
+    def 'simple build without dependencies results in success'() {
+        setup:
+        rootProject()
+                .withAllProjectsPlugin('ca.cutterslade.analyze')
+                .withSubProject(subProject("foo")
+                        .justWarn()
+                        .withMainClass(new GroovyClass("FooClass")
+                                .withClassAnnotation("FooAnnotation", "BarConstants.BAR_VALUE"))
+                        .withMainClass(new GroovyClass("FooAnnotation", true))
+                        .withDependency(new GradleDependency(configuration: "implementation", project: "bar")))
+                .withSubProject(subProject("bar")
+                        .withMainClass(new GroovyClass("BarConstants")
+                                .addClassConstant("BAR_VALUE", "String", "\"dummy value\"")))
+                .withSubProject(subProject("baz")
+                        .withMainClass(new GroovyClass("BazClass")
+                                .addClassConstant("BAZ_VALUE", "String", "BarConstants.BAR_VALUE", false))
+                        .withDependency(new GradleDependency(configuration: "implementation", project: "bar"))
+                )
+                .create(projectDir.getRoot())
+
+        when:
+        def result = gradleProject().forwardOutput().build()
+
+        then:
+        assertBuildResult(result, expectedResult, usedUndeclaredArtifacts, unusedDeclaredArtifacts)
+
+        where:
+        expectedResult | usedUndeclaredArtifacts | unusedDeclaredArtifacts
+        WARNING        | []                      | ["project:bar:unspecified@jar"]
+    }
+}

--- a/src/test/groovy/ca/cutterslade/gradle/analyze/helper/GradleProject.groovy
+++ b/src/test/groovy/ca/cutterslade/gradle/analyze/helper/GradleProject.groovy
@@ -5,11 +5,13 @@ class GradleProject {
     final String name
     final boolean rootProject
 
+    boolean justWarn = false
     Set<GradleProject> subProjects = []
     Set<GroovyClass> mainClasses = []
     Set<GroovyClass> testClasses = []
     Set<GroovyClass> testFixturesClasses = []
     Set<String> plugins = []
+    Set<String> allProjectPlugins = []
     Set<GradleDependency> dependencies = []
     String repositories
     String platformConfiguration = ""
@@ -41,6 +43,16 @@ class GradleProject {
 
     def withPlugin(String plugin) {
         plugins.add(plugin)
+        this
+    }
+
+    def withAllProjectsPlugin(String plugin) {
+        allProjectPlugins.add(plugin)
+        this
+    }
+
+    def justWarn() {
+        justWarn = true
         this
     }
 
@@ -81,7 +93,7 @@ class GradleProject {
                 "    }\n" +
                 "}\n" +
                 "dependencies {\n" +
-                "    myPlatform platform(project(':platform'))" +
+                "    myPlatform platform(project(':platform'))\n" +
                 "}\n"
         this
     }
@@ -154,6 +166,20 @@ class GradleProject {
             buildGradle += "}\n"
         }
         buildGradle += platformConfiguration
+
+        if (rootProject && !allProjectPlugins.empty) {
+            buildGradle += "allprojects {\n"
+            for (def plugin : allProjectPlugins) {
+                buildGradle += "  apply plugin: '${plugin}'\n"
+            }
+            buildGradle += "}\n"
+        }
+
+        if (justWarn) {
+            buildGradle += "analyzeClassesDependencies {\n" +
+                    "  justWarn = ${justWarn}\n" +
+                    "}\n"
+        }
 
         new File(root, "build.gradle").text = buildGradle
     }

--- a/src/test/groovy/ca/cutterslade/gradle/analyze/helper/GroovyClass.groovy
+++ b/src/test/groovy/ca/cutterslade/gradle/analyze/helper/GroovyClass.groovy
@@ -2,10 +2,20 @@ package ca.cutterslade.gradle.analyze.helper
 
 class GroovyClass {
     String name
+    boolean annotation
     Set<String> usedClasses = []
+    Set<Tuple3<String, String, String>> usedClassConstants = []
+    Set<Tuple4<String, String, String, Boolean>> classConstants = []
+    Set<Tuple2<String, String>> classAnnotations = []
 
-    GroovyClass(String name) {
+    GroovyClass(String name, annotation = false) {
+        this.annotation = annotation
         this.name = name
+    }
+
+    def withClassAnnotation(String annotationName, String value) {
+        classAnnotations.add(new Tuple2<String, String>(annotationName, value))
+        this
     }
 
     def usesClass(String clazz) {
@@ -13,18 +23,68 @@ class GroovyClass {
         this
     }
 
+    def addClassConstant(String constantName, String constantType, String constantValue, boolean isFinal = true) {
+        classConstants.add(new Tuple4<String, String, String, Boolean>(constantType, constantName, constantValue, isFinal))
+        this
+    }
+
+    def usesClassConstant(String clazz, String constantName, String constantType) {
+        usedClassConstants.add(new Tuple3(clazz, constantName, constantType))
+        this
+    }
+
     private def buildUsedClasses() {
         def out = ""
         for (String clazz : usedClasses) {
             def var = clazz.contains('.') ? clazz.substring(clazz.lastIndexOf('.') + 1) : clazz
-            out += "  ${clazz} _${var.toLowerCase()}\n"
+            out += "  private ${clazz} _${var.toLowerCase()}\n"
+        }
+        out
+    }
+
+    private def buildUsedConstants() {
+        def out = ""
+        for (Tuple3<String, String, String> usedConst : usedClassConstants) {
+            out += "  private ${usedConst.third} _${usedConst.second.toLowerCase()} = ${usedConst.first}.${usedConst.second}\n"
+        }
+        out
+    }
+
+    private def buildClassConstants() {
+        def out = ""
+        for (Tuple4<String, String, String, Boolean> classConst : classConstants) {
+            out += "  public static ${classConst.fourth ? "final " : ""}${classConst.first} ${classConst.second} = ${classConst.third}\n"
+        }
+        out
+    }
+
+    private def buildClassAnnotation() {
+        def out = ""
+        for (Tuple2<String, String> annotation : classAnnotations) {
+            out += "@${annotation.first}(${annotation.second})\n"
         }
         out
     }
 
     def create(File dir) {
-        def out = "class ${name} {\n"
-        out += buildUsedClasses()
+        def out = ""
+        if (annotation) {
+            out += "import java.lang.annotation.ElementType\n"
+            out += "import java.lang.annotation.Retention\n"
+            out += "import java.lang.annotation.RetentionPolicy\n"
+            out += "import java.lang.annotation.Target\n\n"
+            out += "@Target(ElementType.TYPE)\n"
+            out += "@Retention(RetentionPolicy.RUNTIME)\n"
+            out += buildClassAnnotation()
+            out += "public @interface ${name} {\n"
+            out += "  String value()\n"
+        } else {
+            out += buildClassAnnotation()
+            out += "class ${name} {\n"
+            out += buildClassConstants()
+            out += buildUsedClasses()
+            out += buildUsedConstants()
+        }
         out += "}"
         new File(dir, "${name}.groovy").text = out
     }


### PR DESCRIPTION
Clarify the capability for detecting constants when used across different gradle subprojects, as the may get inlined so that only an import is present in the resulting class file or in case of annotations using a constant from a different gradle subproject the are getting completely erased in the resulting byte code which lead to a unusedDeclaredDependency failure

closes #170 