### PR TITLE
Update Gradle Wrapper from 7.0.1 to 7.0.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=ca42877db3519b667cd531c414be517b294b0467059d401e7133f0e55b9bf265
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-all.zip
+distributionSha256Sum=13bf8d3cf8eeeb5770d19741a59bde9bd966dd78d17f1bbad787a05ef19d1c2d
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update Gradle Wrapper from 7.0.1 to 7.0.2.

Read the release notes: https://docs.gradle.org/7.0.2/release-notes.html

---

The checksums of the Wrapper JAR and the distribution binary have been successfully verified.

- Gradle release: `7.0.2`
- Distribution (-all) zip checksum: `13bf8d3cf8eeeb5770d19741a59bde9bd966dd78d17f1bbad787a05ef19d1c2d`
- Wrapper JAR Checksum: `e996d452d2645e70c01c11143ca2d3742734a28da2bf61f25c82bdc288c9e637`

You can find the reference checksum values at https://gradle.org/release-checksums/

---

🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.

<details>
<summary>Need help? 🤔</summary>
<br />

If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
</details>