### PR TITLE
fix message about broken Gradle war plugin

### DIFF
--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
@@ -57,7 +57,8 @@ class AnalyzeDependenciesPlugin implements Plugin<Project> {
 
                 project.afterEvaluate {
                     analyzeTask.configure {
-                        if (!project.configurations.findByName("providedRuntime")?.resolvedConfiguration?.firstLevelModuleDependencies?.isEmpty()) {
+                        final def configuration = project.configurations.findByName("providedRuntime")
+                        if (configuration != null && !configuration.resolvedConfiguration.firstLevelModuleDependencies.empty) {
                             GradleVersionUtil.warnAboutWarPluginBrokenWhenUsingProvidedRuntime(GradleVersion.current(), project.logger)
                         }
 

--- a/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginGradleSpec.groovy
+++ b/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginGradleSpec.groovy
@@ -93,6 +93,7 @@ class AnalyzeDependenciesPluginGradleSpec extends AnalyzeDependenciesPluginBaseS
 
         then:
         assertBuildResult(result, expectedResult, [], unusedDeclaredArtifacts)
+        result.output.contains('https://github.com/gradle/gradle/issues/17415') == isWarPluginBrokenWhenUsingProvidedRuntime(gradleVersion)
 
         where:
         pair << determineMinorVersions('6.9', '7.3')


### PR DESCRIPTION
only show message when providedRuntime configuration is present and if so it contains a dependency

Closes #220 