### PR TITLE
use dedicated log files for each task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation('org.apache.maven.shared:maven-dependency-analyzer:1.11.3') {
         exclude group: 'org.apache.maven'
     }
-    implementation 'org.ow2.asm:asm:9.2'
+    runtimeOnly 'org.ow2.asm:asm:9.2'
 
     testImplementation('org.spockframework:spock-core:2.0-groovy-3.0') {
         exclude group: 'org.codehaus.groovy'

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/logging/AnalyzeDependenciesFileLogger.java
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/logging/AnalyzeDependenciesFileLogger.java
@@ -10,17 +10,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import ca.cutterslade.gradle.analyze.AnalyzeDependenciesTask;
-
 public class AnalyzeDependenciesFileLogger extends AnalyzeDependenciesLogger implements AutoCloseable {
     private final PrintWriter writer;
 
-    public AnalyzeDependenciesFileLogger(final Path buildDirPath) {
+    public AnalyzeDependenciesFileLogger(final Path logFilePath) {
         try {
-            final Path outputDirectoryPath = buildDirPath.resolve(AnalyzeDependenciesTask.DEPENDENCY_ANALYZE_DEPENDENCY_DIRECTORY_NAME);
-            Files.createDirectories(outputDirectoryPath);
-            final Path analyzeOutputPath = outputDirectoryPath.resolve("analyzeDependencies.log");
-            writer = new PrintWriter(Files.newOutputStream(analyzeOutputPath));
+            Files.createDirectories(logFilePath.getParent());
+            writer = new PrintWriter(Files.newOutputStream(logFilePath));
         } catch (final Exception e) {
             throw new RuntimeException("unable to create file for logging", e);
         }
@@ -28,13 +24,13 @@ public class AnalyzeDependenciesFileLogger extends AnalyzeDependenciesLogger imp
 
     @Override
     public void info(final String title) {
-        writer.println(title);
+        writer.println(title.trim());
         writer.println();
     }
 
     @Override
     public void info(final String title, final Collection<?> files) {
-        writer.println(title);
+        writer.println(title.trim());
         files.stream()
                 .filter(Objects::nonNull)
                 .map(f -> f instanceof File ? ((File) f).getName() : f.toString())
@@ -46,7 +42,7 @@ public class AnalyzeDependenciesFileLogger extends AnalyzeDependenciesLogger imp
 
     @Override
     public void info(final String title, final Map<File, Set<String>> fileMap) {
-        writer.println(title);
+        writer.println(title.trim());
         fileMap.entrySet().stream()
                 .sorted(Comparator.comparing(e -> e.getKey().getName()))
                 .forEach(e -> {

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/logging/AnalyzeDependenciesLogger.java
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/logging/AnalyzeDependenciesLogger.java
@@ -23,11 +23,10 @@ public abstract class AnalyzeDependenciesLogger {
                               Map<File, Set<String>> fileMap);
 
     public static ProjectDependencyAnalysisResult create(final Logger gradleLogger,
-                                                         final Path buildDirPath,
-                                                         final boolean writeToFile,
+                                                         final Path logFilePath,
                                                          @ClosureParams(value = SimpleType.class, options = "ca.cutterslade.gradle.analyze.logging.AnalyzeDependenciesLogger") final Closure<ProjectDependencyAnalysisResult> withLogger) {
-        if (writeToFile) {
-            try (final AnalyzeDependenciesFileLogger logger = new AnalyzeDependenciesFileLogger(buildDirPath)) {
+        if (logFilePath != null) {
+            try (final AnalyzeDependenciesFileLogger logger = new AnalyzeDependenciesFileLogger(logFilePath)) {
                 return withLogger.call(logger);
             }
         } else {

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/util/ProjectDependencyAnalysisResultHandler.java
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/util/ProjectDependencyAnalysisResultHandler.java
@@ -1,6 +1,5 @@
 package ca.cutterslade.gradle.analyze.util;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -18,8 +17,7 @@ public class ProjectDependencyAnalysisResultHandler {
     public static void warnAndLogOrFail(final ProjectDependencyAnalysisResult result,
                                         final boolean warnUsedUndeclared,
                                         final boolean warnUnusedDeclared,
-                                        final boolean logDependencyInformationToFiles,
-                                        final File logFile,
+                                        final Path logFilePath,
                                         final Logger logger) throws IOException {
         final String usedUndeclaredViolations = getArtifactSummary("usedUndeclaredArtifacts", result.getUsedUndeclaredArtifacts());
         final String unusedDeclaredViolations = getArtifactSummary("unusedDeclaredArtifacts", result.getUnusedDeclaredArtifacts());
@@ -27,8 +25,7 @@ public class ProjectDependencyAnalysisResultHandler {
         final String combinedViolations = usedUndeclaredViolations.concat(unusedDeclaredViolations);
 
         if (!combinedViolations.isEmpty()) {
-            if (logDependencyInformationToFiles) {
-                final Path logFilePath = logFile.toPath();
+            if (logFilePath != null) {
                 Files.createDirectories(logFilePath.getParent());
                 Files.newBufferedWriter(logFilePath).append(combinedViolations).close();
             }
@@ -64,7 +61,7 @@ public class ProjectDependencyAnalysisResultHandler {
                             + resolvedArtifact.getModuleVersion().getId()
                             + (resolvedArtifact.getClassifier() != null ? ":" + resolvedArtifact.getClassifier() : "") + "@"
                             + resolvedArtifact.getExtension())
-                    .collect(Collectors.joining("\n", sectionName + ": \n", "")) + "\n";
+                    .collect(Collectors.joining("\n", sectionName + "\n", "")) + "\n";
         } else {
             return "";
         }

--- a/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginBaseSpec.groovy
+++ b/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginBaseSpec.groovy
@@ -45,10 +45,11 @@ abstract class AnalyzeDependenciesPluginBaseSpec extends Specification {
             }
         }
         GradleRunner.create()
+        .withDebug(true)
                 .withProjectDir(projectDir)
                 .withPluginClasspath()
                 .forwardOutput()
-                .withArguments()
+                .withArguments("--stacktrace")
     }
 
     protected static void assertBuildSuccess(BuildResult result) {
@@ -95,11 +96,11 @@ abstract class AnalyzeDependenciesPluginBaseSpec extends Specification {
             violations.append('Dependency analysis found issues.\n')
             def spacer = expectedResult == WARNING ? '' : '  '
             if (!usedUndeclaredArtifacts.empty) {
-                violations.append(spacer).append('usedUndeclaredArtifacts: \n')
+                violations.append(spacer).append('usedUndeclaredArtifacts\n')
                 usedUndeclaredArtifacts.each { violations.append(spacer).append(" - ${it}\n") }
             }
             if (!unusedDeclaredArtifacts.empty) {
-                violations.append(spacer).append('unusedDeclaredArtifacts: \n')
+                violations.append(spacer).append('unusedDeclaredArtifacts\n')
                 unusedDeclaredArtifacts.each { violations.append(spacer).append(" - ${it}\n") }
             }
             violations.append('\n')

--- a/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginFileLoggingSpec.groovy
+++ b/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginFileLoggingSpec.groovy
@@ -83,7 +83,7 @@ class AnalyzeDependenciesPluginFileLoggingSpec extends AnalyzeDependenciesPlugin
 
         then:
         assertBuildSuccess(result)
-        assertLogFile(projectDir, 'complex_analyzeDependencies.log', 'analyzeDependencies.log')
+        assertLogFile(projectDir, 'complex_analyzeDependencies.log', 'analyzeClassesDependencies.log')
     }
 
     private static void assertLogFile(final File projectDir,

--- a/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginGradleSpec.groovy
+++ b/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginGradleSpec.groovy
@@ -142,7 +142,7 @@ class AnalyzeDependenciesPluginGradleSpec extends AnalyzeDependenciesPluginBaseS
             StreamSupport.stream(versions.spliterator(), false)
                     .filter { node -> !node.get("broken") }
                     .map { node -> GradleVersion.version(node.get("version").asText()) }
-                    .filter { version -> version >= minGradleVersion && version < maxGradleVersion }
+                    .filter { version -> version >= minGradleVersion && version <= maxGradleVersion }
                     .filter { version -> version == version.getBaseVersion() }
                     .sorted { a, b -> a <=> b }
                     .collect(Collectors.toList())

--- a/src/test/resources/analyzeClassesDependencies.log
+++ b/src/test/resources/analyzeClassesDependencies.log
@@ -1,2 +1,2 @@
-unusedDeclaredArtifacts: 
+unusedDeclaredArtifacts
  - org.springframework.boot:spring-boot-starter:2.3.6.RELEASE@jar


### PR DESCRIPTION
previously `analyzeTestClassesDependencies` and `analyzeClassesDependencies` task results could override each other causing the up-to-date check to fail

fixes #229 