### PR TITLE
preserve order of classpath entries when detecting which classes are …

### DIFF
--- a/src/main/groovy/ca/cutterslade/gradle/analyze/ProjectDependencyResolver.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/ProjectDependencyResolver.groovy
@@ -170,15 +170,15 @@ class ProjectDependencyResolver {
         }
     }
 
-    private Set<ResolvedDependency> getRequiredDependencies() {
+    private List<ResolvedDependency> getRequiredDependencies() {
         getFirstLevelDependencies(require)
     }
 
-    private Set<ResolvedDependency> getAllowedToUseDependencies() {
+    private List<ResolvedDependency> getAllowedToUseDependencies() {
         getFirstLevelDependencies(allowedToUse)
     }
 
-    private Set<ResolvedDependency> getAllowedToDeclareDependencies() {
+    private List<ResolvedDependency> getAllowedToDeclareDependencies() {
         getFirstLevelDependencies(allowedToDeclare)
     }
 
@@ -189,8 +189,8 @@ class ProjectDependencyResolver {
      * @return a Map of files to their classes
      * @throws IOException
      */
-    private Map<File, Set<String>> buildArtifactClassMap(Set<File> dependencyArtifacts) throws IOException {
-        final Map<File, Set<String>> artifactClassMap = [:]
+    private Map<File, Set<String>> buildArtifactClassMap(List<File> dependencyArtifacts) throws IOException {
+        final Map<File, Set<String>> artifactClassMap = new LinkedHashMap<>()
 
         int hits = 0
         int misses = 0

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/util/ProjectDependencyResolverUtils.java
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/util/ProjectDependencyResolverUtils.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -36,7 +35,7 @@ public final class ProjectDependencyResolverUtils {
      */
     public static Map<File, Set<String>> buildUsedArtifacts(final Map<File, Set<String>> artifactClassMap,
                                                             final Collection<String> dependencyClasses) {
-        final Map<File, Set<String>> map = new HashMap<>();
+        final Map<File, Set<String>> map = new LinkedHashMap<>();
         dependencyClasses.forEach(className ->
                 artifactClassMap.entrySet().stream()
                         .filter(e -> e.getValue().contains(className))
@@ -56,28 +55,31 @@ public final class ProjectDependencyResolverUtils {
                 .collect(Collectors.toSet());
     }
 
-    public static Set<ResolvedDependency> getFirstLevelDependencies(final Collection<Configuration> configurations) {
+    public static List<ResolvedDependency> getFirstLevelDependencies(final Collection<Configuration> configurations) {
         return configurations.stream()
                 .map(Configuration::getResolvedConfiguration)
                 .map(ResolvedConfiguration::getFirstLevelModuleDependencies)
                 .flatMap(Collection::stream)
-                .collect(Collectors.toSet());
+                .distinct()
+                .collect(Collectors.toList());
     }
 
-    public static Set<File> findModuleArtifactFiles(final Collection<ResolvedDependency> dependencies) {
+    public static List<File> findModuleArtifactFiles(final Collection<ResolvedDependency> dependencies) {
         return dependencies.stream()
                 .map(ResolvedDependency::getModuleArtifacts)
                 .flatMap(Collection::stream)
                 .map(ResolvedArtifact::getFile)
-                .collect(Collectors.toSet());
+                .distinct()
+                .collect(Collectors.toList());
     }
 
-    public static Set<File> findAllModuleArtifactFiles(final Collection<ResolvedDependency> dependencies) {
+    public static List<File> findAllModuleArtifactFiles(final Collection<ResolvedDependency> dependencies) {
         return dependencies.stream()
                 .map(ResolvedDependency::getAllModuleArtifacts)
                 .flatMap(Collection::stream)
                 .map(ResolvedArtifact::getFile)
-                .collect(Collectors.toSet());
+                .distinct()
+                .collect(Collectors.toList());
     }
 
     public static Map<ResolvedArtifact, Collection<ResolvedArtifact>> used(final List<ComponentIdentifier> allDependencyArtifacts,
@@ -131,7 +133,7 @@ public final class ProjectDependencyResolverUtils {
         } else {
             final Map<String, ResolvedArtifact> resolvedArtifacts = resolveArtifacts(allowedAggregatorsToUse).stream()
                     .collect(Collectors.toMap(d -> d.getModuleVersion().toString(), Function.identity()));
-            final Set<ResolvedDependency> dependencies = getFirstLevelDependencies(allowedAggregatorsToUse);
+            final List<ResolvedDependency> dependencies = getFirstLevelDependencies(allowedAggregatorsToUse);
             return dependencies.stream()
                     .filter(d -> resolvedArtifacts.containsKey(d.getName()))
                     .collect(Collectors.toMap(d -> resolvedArtifacts.get(d.getName()), ResolvedDependency::getAllModuleArtifacts));

--- a/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginBaseSpec.groovy
+++ b/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginBaseSpec.groovy
@@ -45,7 +45,6 @@ abstract class AnalyzeDependenciesPluginBaseSpec extends Specification {
             }
         }
         GradleRunner.create()
-        .withDebug(true)
                 .withProjectDir(projectDir)
                 .withPluginClasspath()
                 .forwardOutput()

--- a/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginClasspathOrder.groovy
+++ b/src/test/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPluginClasspathOrder.groovy
@@ -1,0 +1,50 @@
+package ca.cutterslade.gradle.analyze
+
+import ca.cutterslade.gradle.analyze.helper.GradleDependency
+import ca.cutterslade.gradle.analyze.helper.GroovyClass
+
+class AnalyzeDependenciesPluginClasspathOrder extends AnalyzeDependenciesPluginBaseSpec {
+    def 'project with two dependencies ordered: first-second'() {
+        setup:
+        rootProject()
+                .withMainClass(new GroovyClass('Main')
+                        .usesClass('One')
+                        .usesClass("Two"))
+                .withSubProject(subProject('first')
+                        .withMainClass(new GroovyClass('One')))
+                .withSubProject(subProject('second')
+                        .withMainClass(new GroovyClass('One'))
+                        .withMainClass(new GroovyClass("Two")))
+                .withDependency(new GradleDependency(configuration: 'implementation', project: 'first'))
+                .withDependency(new GradleDependency(configuration: 'implementation', project: 'second'))
+                .create(projectDir)
+
+        when:
+        def result = buildGradleProject(SUCCESS)
+
+        then:
+        assertBuildResult(result, SUCCESS)
+    }
+
+    def 'project with two dependencies ordered: second-first'() {
+        setup:
+        rootProject()
+                .withMainClass(new GroovyClass('Main')
+                        .usesClass('One')
+                        .usesClass("Two"))
+                .withSubProject(subProject('first')
+                        .withMainClass(new GroovyClass('One')))
+                .withSubProject(subProject('second')
+                        .withMainClass(new GroovyClass('One'))
+                        .withMainClass(new GroovyClass("Two")))
+                .withDependency(new GradleDependency(configuration: 'implementation', project: 'second'))
+                .withDependency(new GradleDependency(configuration: 'implementation', project: 'first'))
+                .create(projectDir)
+
+        when:
+        def result = buildGradleProject(VIOLATIONS)
+
+        then:
+        assertBuildResult(result, VIOLATIONS, [], ['project:first:unspecified@jar'])
+    }
+}


### PR DESCRIPTION
…used from which dependency

this resolves an issue when two classes are present in different dependencies with the same name and package.
The default behaviour from java is to check each jar on the classpath in order to find the correct one (the one that should be used).
still, this can have some side effects, but at least the behaviour is consistent.

fixes #239 